### PR TITLE
Roaring Flip for single index and range

### DIFF
--- a/Source/Container.cs
+++ b/Source/Container.cs
@@ -187,12 +187,37 @@ namespace BitsetsNET
          * @param x other container
          * @return whether they intersect
          */
+
+        
+        public abstract Container inot(int start, int end);
+
         public bool intersects(Container x)
         {
             if (x is ArrayContainer)
                 return intersects((ArrayContainer)x);
             return intersects((BitsetContainer)x);
         }
+
+        /// <summary>
+        /// Create a container initialized with a range of consecutive values
+        /// </summary>
+        /// <param name="start">first index</param>
+        /// <param name="last">last index</param>
+        /// <returns>return a new container initialized with the specified values</returns>
+        /// <remarks>In the original lemire version, there is some optimization here
+        /// to choose between an ArrayContainer and a RunContainer based on serialized size.
+        /// For now, this has been stripped out and always uses an ArrayContainer.</remarks>
+        public static Container rangeOfOnes(ushort start, ushort last)
+        {
+            //TODO: Add in logic for RunContainers
+            Container answer = new ArrayContainer();
+            answer = answer.iadd(start, last);
+            return answer;
+        }
+
+        public abstract Container flip(ushort x);
+
+        public abstract Container iadd(ushort begin, ushort end);
 
         /**
          * Returns true if the current container intersects the other container.

--- a/Source/RLE/RLEBitset.cs
+++ b/Source/RLE/RLEBitset.cs
@@ -22,6 +22,11 @@ namespace BitsetsNET
                 EndIndex = endIdx;
             }
 
+            internal static int serializedSizeInBytes(int numberOfRuns)
+            {
+                return 2 + 2 * 2 * numberOfRuns;
+            }
+
         }
 
         #endregion

--- a/Source/Utility.cs
+++ b/Source/Utility.cs
@@ -8,20 +8,84 @@ namespace BitsetsNET
 {
     class Utility
     {
+        /// <summary>
+        /// Gets the 16 highest-order bits from an integer.
+        /// </summary>
+        /// <param name="x">The integer to shift</param>
+        /// <returns>The highest-order bits</returns>
         public static ushort GetHighBits(int x)
         {
             uint u = (uint)(x);
             return (ushort) (u >> 16);
         }
 
+        /// <summary>
+        /// Gets the 16 lowest-order bits from an integer.
+        /// </summary>
+        /// <param name="x">The integer to shift</param>
+        /// <returns>The lowest-order bits</returns>
         public static ushort GetLowBits(int x)
         {
             return (ushort)(x & 0xFFFF);
         }
 
-        public static uint toIntUnsigned(ushort x)
+        public static int GetMaxLowBitAsInteger()
         {
-            return (uint) x;
+            return (int) 0xFFFF;
+        }
+
+        public static int toIntUnsigned(ushort x)
+        {
+            return (int) x;
+        }
+
+        public static void flipBitsetRange(long[] bitset, int start, int end)
+        {
+            if (start == end)
+            {
+                return;
+            }
+            uint firstword = (uint) (start / 64);
+            uint endword = (uint) (end - 1) / 64;
+            bitset[firstword] ^= ~(long)(ulong.MaxValue << start);
+            for (uint i = firstword; i < endword; i++)
+            {
+                bitset[i] = ~bitset[i];
+            }
+
+            bitset[endword] ^= (long)(ulong.MaxValue >> -end);
+        }
+
+        public static int flipBitsetRangeAndCardinalityChange(long[] bitmap, int start, int end)
+        {
+            int cardbefore = cardinalityInBitmapWordRange(bitmap, start, end);
+            flipBitsetRange(bitmap, start, end);
+            int cardafter = cardinalityInBitmapWordRange(bitmap, start, end);
+            return cardafter - cardbefore;
+        }
+
+        /**
+   * Hamming weight of the 64-bit words involved in the range
+   *  start, start+1,..., end-1
+   * 
+   * @param bitmap array of words to be modified
+   * @param start first index to be modified (inclusive)
+   * @param end last index to be modified (exclusive)
+   */
+        public static int cardinalityInBitmapWordRange(long[] bitmap, int start, int end)
+        {
+            if (start == end)
+            {
+                return 0;
+            }
+            int firstword = start / 64;
+            int endword = (end - 1) / 64;
+            int answer = 0;
+            for (int i = firstword; i <= endword; i++)
+            {
+                answer += longBitCount(bitmap[i]);
+            }
+            return answer;
         }
 
         public static int unsignedBinarySearch(ushort[] array, int begin, int end, ushort key) {
@@ -339,7 +403,7 @@ namespace BitsetsNET
         /// greater than b, or zero if they are equal</returns>
         public static uint compareUnsigned(ushort a, ushort b)
         {
-            return toIntUnsigned(a) - toIntUnsigned(b);
+            return (uint) (toIntUnsigned(a) - toIntUnsigned(b));
         }
 
         /// <summary>


### PR DESCRIPTION
Roaring Flip now passing all tests for flipping single indices and a range. This resolves issues #37 and #38.

Remarks: there's one small section of code that creates a range of ones in the original Java:

``` java
public static Container rangeOfOnes(final int start, final int last) {
    final int sizeAsArrayContainer = ArrayContainer.serializedSizeInBytes(last - start);
    final int sizeAsRunContainer = RunContainer.serializedSizeInBytes(1);
    Container answer =
        sizeAsRunContainer < sizeAsArrayContainer ? new RunContainer() : new ArrayContainer();
    answer = answer.iadd(start, last);
    return answer;
  }
```

This optimization compares serialized sizes of Array vs Run containers and creates the smallest one.

The RLE stuff in our port isn't directly analogous to this (no run container that inherits from Container base), so I just default to ArrayContainer:

``` c#
public static Container rangeOfOnes(ushort start, ushort last)
{
    //TODO: Add in logic for RunContainers?
    Container answer = new ArrayContainer();
    answer = answer.iadd(start, last);
    return answer;
}
```
