### PR TITLE
Remove ToBitArray from interface

### DIFF
--- a/Source/IBitset.cs
+++ b/Source/IBitset.cs
@@ -63,13 +63,6 @@ namespace BitsetsNET
         /// <returns>a new IBitSet</returns>
         IBitset Difference(IBitset otherSet);
 
-        /// <summary>
-        /// Returns the contents of this set as a bit array where the value is
-        /// set to true for each index that is a member of this set
-        /// </summary>
-        /// <returns>a new BitArray</returns>
-        BitArray ToBitArray();
-
         bool Equals(object obj);
 
         /// <summary>

--- a/Source/RoaringBitset.cs
+++ b/Source/RoaringBitset.cs
@@ -740,10 +740,5 @@ namespace BitsetsNET
             }
             
         }
-
-        public BitArray ToBitArray()
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/Tests/BaseBitSetTests.cs
+++ b/Tests/BaseBitSetTests.cs
@@ -217,38 +217,6 @@ namespace BitsetsNET.Tests
         }
 
         [TestMethod]
-        public virtual void ToBitArrayTest()
-        {
-            int[] set = SetGenerator.GetRandomArray(TEST_SET_LENGTH);
-            BitArray setArray = new BitArray(TEST_SET_LENGTH);
-
-            foreach (int index in set)
-            {
-                setArray[index] = true;
-            }
-
-            IBitset testSet = CreateSetFromIndices(set, TEST_SET_LENGTH);
-            BitArray testArray = testSet.ToBitArray();
-
-            bool expected = true;
-            bool actual = true;
-
-            for (int i = 0; i < setArray.Length; i++)
-            {
-                if (setArray[i])
-                {
-                    actual &= setArray[i] == testArray[i];
-                }
-                else
-                {
-                    //do nothing
-                }
-            }
-
-            Assert.AreEqual(expected, actual);
-        }
-
-        [TestMethod]
         public virtual void CardinalityTest()
         {
             int[] set = SetGenerator.GetContiguousArray(1, 5000);

--- a/Tests/RLEBitsetTests.cs
+++ b/Tests/RLEBitsetTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -32,6 +33,39 @@ namespace BitsetsNET.Tests
             }
 
             Assert.AreEqual(actual, expected);
+        }
+
+        [TestMethod()]
+        public virtual void ToBitArrayTest()
+        {
+            int TEST_SET_LENGTH = 10;
+            int[] set = SetGenerator.GetRandomArray(TEST_SET_LENGTH);
+            BitArray setArray = new BitArray(TEST_SET_LENGTH);
+
+            foreach (int index in set)
+            {
+                setArray[index] = true;
+            }
+
+            RLEBitset testSet = (RLEBitset)CreateSetFromIndices(set, TEST_SET_LENGTH);
+            BitArray testArray = testSet.ToBitArray();
+
+            bool expected = true;
+            bool actual = true;
+
+            for (int i = 0; i < setArray.Length; i++)
+            {
+                if (setArray[i])
+                {
+                    actual &= setArray[i] == testArray[i];
+                }
+                else
+                {
+                    //do nothing
+                }
+            }
+
+            Assert.AreEqual(expected, actual);
         }
 
     }


### PR DESCRIPTION
I removed ToBitArray from the iBitSet interface. I left the implementation for RLE and moved the test to the RLE specific class.
