### PR TITLE
Feature/variable size or fix

### DIFF
--- a/Source/BItsetContainer.cs
+++ b/Source/BItsetContainer.cs
@@ -492,7 +492,7 @@ namespace BitsetsNET
                 long aft = w | (1L << v);
                 this.Bitmap[i] = aft;
 
-                this.Cardinality += (int)((w - aft) >> 63);
+                this.Cardinality += (int)(((w - aft) >> 63) & 1);
             }
             return this;
         }
@@ -534,7 +534,7 @@ namespace BitsetsNET
                 long aft = w | (1L << v);
 
                 answer.Bitmap[i] = aft;
-                answer.Cardinality += (int)((w - aft) >> 63);
+                answer.Cardinality += (int)(((w - aft) >> 63) & 1);
             }
             return answer;
         }

--- a/Source/BItsetContainer.cs
+++ b/Source/BItsetContainer.cs
@@ -617,7 +617,7 @@ namespace BitsetsNET
                 {
                     return false;
                 }
-                return Array.Equals(this.Bitmap, srb.Bitmap);
+                return this.Bitmap.SequenceEqual(srb.Bitmap);
             } 
             return false;
         }

--- a/Tests/RoaringBitSetTests.cs
+++ b/Tests/RoaringBitSetTests.cs
@@ -119,5 +119,67 @@ namespace BitsetsNET.Tests
             Assert.AreEqual(true, testSet4.Get(6));
 
         }
+
+        /*
+         The roaring bit set stores 2 different types of containers. 
+         The switch is based primarily on size, Array (small) and Bitset (large).
+         We want to ensure logic works between large and small containers.
+        */
+
+        [TestMethod()]
+        public virtual void VariedSizeOrTest()
+        {
+            int largeSize = 100000;
+            int smallSize = 100;
+            int[] first = SetGenerator.GetRandomArray(largeSize);
+            int[] second = SetGenerator.GetRandomArray(smallSize);
+            int[] result = first.Union(second).ToArray();
+            IBitset expected = CreateSetFromIndices(result, largeSize);
+            IBitset actual = CreateSetFromIndices(first, largeSize).Or(CreateSetFromIndices(second, smallSize));
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod()]
+        public virtual void VariedSizeOrWithTest()
+        {
+            int largeSize = 100000;
+            int smallSize = 100;
+            int[] first = SetGenerator.GetRandomArray(largeSize);
+            int[] second = SetGenerator.GetRandomArray(smallSize);
+            int[] result = first.Union(second).ToArray();
+            IBitset testSet = CreateSetFromIndices(first, largeSize);
+            testSet.OrWith(CreateSetFromIndices(second, smallSize));
+
+            Assert.AreEqual(CreateSetFromIndices(result, largeSize), testSet);
+        }
+
+        [TestMethod()]
+        public virtual void VariedSizeAndTest()
+        {
+            int largeSize = 100000;
+            int smallSize = 100;
+            int[] first = SetGenerator.GetRandomArray(largeSize);
+            int[] second = SetGenerator.GetRandomArray(smallSize);
+            int[] result = first.Intersect(second).ToArray();
+            IBitset expected = CreateSetFromIndices(result, largeSize);
+            IBitset actual = CreateSetFromIndices(first, largeSize).And(CreateSetFromIndices(second, smallSize));
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod()]
+        public virtual void VariedSizeAndWithTest()
+        {
+            int largeSize = 100000;
+            int smallSize = 100;
+            int[] first = SetGenerator.GetRandomArray(largeSize);
+            int[] second = SetGenerator.GetRandomArray(smallSize);
+            int[] result = first.Intersect(second).ToArray();
+            IBitset testSet = CreateSetFromIndices(first, largeSize);
+            testSet.AndWith(CreateSetFromIndices(second, smallSize));
+
+            Assert.AreEqual(CreateSetFromIndices(result, largeSize), testSet);
+        }
     }
 }


### PR DESCRIPTION
When doing a logical OR between an ArrayContainer and a BitsetContainer the cardinality calculation is done incorrectly (it changes the right amount in the wrong direction). There also were no unit tests that tested this logic as all unit tests test small, approximately equal sized sets making it unlikely that you would have operations across the two different types of containers.